### PR TITLE
Change from -m <mode> syntax to <verb>, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ Dockerfile
 debpkg/
 build/
 .vscode
+.vs
 extra/

--- a/src/ChatDownloader.c
+++ b/src/ChatDownloader.c
@@ -239,7 +239,7 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 
 	string *cmd = malloc(sizeof(string));
 	*cmd = (string){malloc(sizeof(char) * 100), 0, 100};
-	concat(cmd, 4, getBinaryPath(), " -m ChatDownload -u '", chatOptions->id, "'");
+	concat(cmd, 4, getBinaryPath(), " chatdownload -u '", chatOptions->id, "'");
 
 	if (uiCheckboxChecked(chatOptions->cropStartCheck)) {
 		char seconds[12];

--- a/src/ChatDownloader.c
+++ b/src/ChatDownloader.c
@@ -258,7 +258,7 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 	}
 
 	if (uiCheckboxChecked(chatOptions->embedEmotes)) {
-		concat(cmd, 1, " --embed-emotes ");
+		concat(cmd, 1, " -E ");
 	}
 
 	concat(cmd, 2, " --temp-path ", getJson(configJson, "tempFolder")->valuestring);

--- a/src/ChatRender.c
+++ b/src/ChatRender.c
@@ -232,7 +232,7 @@ static void renderBtnClicked(uiButton *b, void *args) {
 	string *cmd = malloc(sizeof(string));
 	*cmd = (string){malloc(sizeof(char) * 100), 0, 100};
 
-	concat(cmd, 4, getBinaryPath(), " -m ChatRender -i \"", chatFile, "\" ");
+	concat(cmd, 4, getBinaryPath(), " chatrender -i \"", chatFile, "\" ");
 	concat(cmd, 2, " --temp-path ", getJson(configJson, "tempFolder")->valuestring);
 
 	uiFontDescriptor font;

--- a/src/ClipDownloader.c
+++ b/src/ClipDownloader.c
@@ -153,7 +153,7 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 
 	string *cmd = malloc(sizeof(string));
 	*cmd = (string){malloc(sizeof(char) * 100), 0, 100};
-	concat(cmd, 3, getBinaryPath(), " -m ClipDownload -u ", clipOptions->id);
+	concat(cmd, 3, getBinaryPath(), " clipdownload -u ", clipOptions->id);
 	concat(cmd, 2, " --temp-path ", getJson(configJson, "tempFolder")->valuestring);
 	concat(cmd, 2, " -q ", qualityArray[uiComboboxSelected(clipOptions->qualities)]);
 	concat(cmd, 3, " -o ", fileName, " 2>&1");

--- a/src/VodDownloader.c
+++ b/src/VodDownloader.c
@@ -221,7 +221,7 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 
 	string *cmd = malloc(sizeof(string));
 	*cmd = (string){malloc(sizeof(char) * 100), 0, 100};
-	concat(cmd, 4, getBinaryPath(), " -m VideoDownload -u '", vodOptions->id, "'");
+	concat(cmd, 4, getBinaryPath(), " videodownload -u '", vodOptions->id, "'");
 	concat(cmd, 2, " --temp-path ", getJson(configJson, "tempFolder")->valuestring);
 
 	if (uiCheckboxChecked(vodOptions->cropStartCheck)) {


### PR DESCRIPTION
Very soon TwitchDownloaderCLI will switch from `./TwitchDownloaderCLI -m <mode>` to `./TwitchDownloaderCLI <verb>`. While the `-m` syntax will still work, it prints a warning message which you likely won't want showing to users. **So only when the [latest release](https://github.com/lay295/TwitchDownloader/releases/latest) is greater than 1.50.6 merge this.**

Also added `.vs` folder to gitignore

<br>
Wish I could help more with this project, like adding per-service emote embedding, but I don't know enough C