### PR TITLE
Add download bandwidth limit to VOD and Clip download

### DIFF
--- a/src/ClipDownloader.c
+++ b/src/ClipDownloader.c
@@ -83,18 +83,17 @@ uiControl *ClipDownloaderDrawUi(void) {
 
 	uiBoxAppend(middleHorizontalBox, uiControl(uiNewVerticalSeparator()), 0);
 
-	uiForm *qualityForm = uiNewForm();
-	uiFormSetPadded(qualityForm, 1);
-	uiCombobox *qualities = uiNewCombobox();
-	uiFormAppend(qualityForm, "Quality: ", uiControl(qualities), 0);
-	uiBoxAppend(middleHorizontalBox, uiControl(qualityForm), 0);
+	uiForm *optionsForm = uiNewForm();
+	uiFormSetPadded(optionsForm, 1);
 
-	uiForm *dwnBandwidthSpin = uiNewForm();
-	uiFormSetPadded(dwnBandwidthSpin, 1);
+	uiCombobox *qualities = uiNewCombobox();
+	uiFormAppend(optionsForm, "Quality: ", uiControl(qualities), 0);
+
 	uiSpinbox *dwnBandwidthSpin = uiNewSpinbox(128, 40960); // 128KB/s - 40MB/s
 	uiSpinboxSetValue(dwnBandwidthSpin, 8192);
-	uiFormAppend(dwnBandwidthSpin, "Bandwidth Limit (KB/s):", uiControl(dwnBandwidthSpin), 0);
-	uiBoxAppend(middleHorizontalBox, uiControl(dwnBandwidthSpin), 0);
+	uiFormAppend(optionsForm, "Bandwidth Limit (KB/s):", uiControl(dwnBandwidthSpin), 0);
+
+	uiBoxAppend(middleHorizontalBox, uiControl(optionsForm), 0);
 
 	uiBoxAppend(middleHorizontalBox, uiControl(uiNewVerticalSeparator()), 0);
 
@@ -122,8 +121,8 @@ uiControl *ClipDownloaderDrawUi(void) {
 
 	clipOptions = malloc(sizeof(ClipOptions));
 	*clipOptions = (ClipOptions){
-			qualities, dwnBandwidthSpin, linkEntry,		nameLabel, titleLabel, durationLabel, createdLabel, logsEntry, pBar,
-			status,		 downloadBtn, infoBtn,	 NULL,			 NULL,					imageArea,		0,				 handler,
+			qualities, dwnBandwidthSpin, linkEntry, nameLabel, titleLabel, durationLabel, createdLabel, logsEntry, pBar, status, downloadBtn, infoBtn, NULL,
+			NULL,			 imageArea,				 0,					handler,
 	};
 
 	uiButtonOnClicked(infoBtn, infoBtnClicked, NULL);
@@ -163,9 +162,9 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 	*cmd = (string){malloc(sizeof(char) * 100), 0, 100};
 	concat(cmd, 3, getBinaryPath(), " clipdownload -u ", clipOptions->id);
 	concat(cmd, 2, " -q ", qualityArray[uiComboboxSelected(clipOptions->qualities)]);
-	
+
 	char dwnBandwidth[12];
-	sprintf(dwnBandwidth, "%d", uiSpinboxValue(vodOptions->threadBandwidthSpin));
+	sprintf(dwnBandwidth, "%d", uiSpinboxValue(clipOptions->dwnBandwidthSpin));
 	concat(cmd, 2, " --bandwidth ", dwnBandwidth);
 
 	concat(cmd, 3, " -o \"", fileName, "\" ");

--- a/src/ClipDownloader.c
+++ b/src/ClipDownloader.c
@@ -89,6 +89,13 @@ uiControl *ClipDownloaderDrawUi(void) {
 	uiFormAppend(qualityForm, "Quality: ", uiControl(qualities), 0);
 	uiBoxAppend(middleHorizontalBox, uiControl(qualityForm), 0);
 
+	uiForm *dwnBandwidthSpin = uiNewForm();
+	uiFormSetPadded(dwnBandwidthSpin, 1);
+	uiSpinbox *dwnBandwidthSpin = uiNewSpinbox(128, 40960); // 128KB/s - 40MB/s
+	uiSpinboxSetValue(dwnBandwidthSpin, 8192);
+	uiFormAppend(dwnBandwidthSpin, "Bandwidth Limit (KB/s):", uiControl(dwnBandwidthSpin), 0);
+	uiBoxAppend(middleHorizontalBox, uiControl(dwnBandwidthSpin), 0);
+
 	uiBoxAppend(middleHorizontalBox, uiControl(uiNewVerticalSeparator()), 0);
 
 	uiForm *logForm = uiNewForm();
@@ -115,7 +122,7 @@ uiControl *ClipDownloaderDrawUi(void) {
 
 	clipOptions = malloc(sizeof(ClipOptions));
 	*clipOptions = (ClipOptions){
-			qualities, linkEntry,		nameLabel, titleLabel, durationLabel, createdLabel, logsEntry, pBar,
+			qualities, dwnBandwidthSpin, linkEntry,		nameLabel, titleLabel, durationLabel, createdLabel, logsEntry, pBar,
 			status,		 downloadBtn, infoBtn,	 NULL,			 NULL,					imageArea,		0,				 handler,
 	};
 
@@ -156,6 +163,11 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 	*cmd = (string){malloc(sizeof(char) * 100), 0, 100};
 	concat(cmd, 3, getBinaryPath(), " clipdownload -u ", clipOptions->id);
 	concat(cmd, 2, " -q ", qualityArray[uiComboboxSelected(clipOptions->qualities)]);
+	
+	char dwnBandwidth[12];
+	sprintf(dwnBandwidth, "%d", uiSpinboxValue(vodOptions->threadBandwidthSpin));
+	concat(cmd, 2, " --bandwidth ", dwnBandwidth);
+
 	concat(cmd, 3, " -o \"", fileName, "\" ");
 
 	clipOptions->cmd = cmd;

--- a/src/ClipDownloader.h
+++ b/src/ClipDownloader.h
@@ -4,6 +4,7 @@
 
 typedef struct {
 	uiCombobox *qualities;
+	uiSpinbox *dwnBandwidthSpin;
 	uiEntry *linkEntry;
 	uiLabel *nameLabel;
 	uiLabel *titleLabel;

--- a/src/VodDownloader.c
+++ b/src/VodDownloader.c
@@ -144,10 +144,17 @@ uiControl *VodDownloaderDrawUi(void) {
 
 	uiForm *dwnThreadForm = uiNewForm();
 	uiFormSetPadded(dwnThreadForm, 1);
-	uiSpinbox *dwnThreadsSpin = uiNewSpinbox(1, 50);
-	uiSpinboxSetValue(dwnThreadsSpin, 10);
+	uiSpinbox *dwnThreadsSpin = uiNewSpinbox(1, 20);
+	uiSpinboxSetValue(dwnThreadsSpin, 5);
 	uiFormAppend(dwnThreadForm, "Download Threads:", uiControl(dwnThreadsSpin), 0);
 	uiBoxAppend(optionsBox, uiControl(dwnThreadForm), 0);
+
+	uiForm *threadBandwidthSpin = uiNewForm();
+	uiFormSetPadded(threadBandwidthSpin, 1);
+	uiSpinbox *threadBandwidthSpin = uiNewSpinbox(128, 40960); // 128KB/s - 40MB/s
+	uiSpinboxSetValue(threadBandwidthSpin, 2048);
+	uiFormAppend(threadBandwidthSpin, "Bandwidth Per Thread (KB/s):", uiControl(threadBandwidthSpin), 0);
+	uiBoxAppend(optionsBox, uiControl(threadBandwidthSpin), 0);
 
 	uiBoxAppend(middleHorizontalBox, uiControl(uiNewVerticalSeparator()), 0);
 
@@ -177,7 +184,7 @@ uiControl *VodDownloaderDrawUi(void) {
 	*vodOptions = (VodOptions){
 			linkEntry, nameLabel, titleLabel, durationLabel,	createdLabel, logsEntry,		 pBar,					 status,			downloadBtn, infoBtn,
 			NULL,			 NULL,			0,					cropStartCheck, cropEndCheck, startSpinsBox, cropStartBox,	 endSpinsBox, cropEndBox,	 startHour,
-			startMin,	 startSec,	endHour,		endMin,					endSec,				OAuth,				 dwnThreadsSpin, imageArea,		handler,		 0,
+			startMin,	 startSec,	endHour,	endMin,			endSec,			OAuth,		 dwnThreadsSpin, threadBandwidthSpin, imageArea,		handler,	 0,
 	};
 
 	uiButtonOnClicked(infoBtn, infoBtnClicked, NULL);
@@ -243,6 +250,10 @@ static void downloadBtnClicked(uiButton *b, void *data) {
 	char threadCount[12];
 	sprintf(threadCount, "%d", uiSpinboxValue(vodOptions->dwnThreadsSpin));
 	concat(cmd, 2, " -t ", threadCount);
+
+	char threadBandwidth[12];
+	sprintf(threadBandwidth, "%d", uiSpinboxValue(vodOptions->threadBandwidthSpin));
+	concat(cmd, 2, " --bandwidth ", threadBandwidth);
 
 	char *OAuth = uiEntryText(vodOptions->OAuth);
 	if (strlen(OAuth))

--- a/src/VodDownloader.c
+++ b/src/VodDownloader.c
@@ -149,12 +149,12 @@ uiControl *VodDownloaderDrawUi(void) {
 	uiFormAppend(dwnThreadForm, "Download Threads:", uiControl(dwnThreadsSpin), 0);
 	uiBoxAppend(optionsBox, uiControl(dwnThreadForm), 0);
 
-	uiForm *threadBandwidthSpin = uiNewForm();
-	uiFormSetPadded(threadBandwidthSpin, 1);
+	uiForm *threadBandwidthForm = uiNewForm();
+	uiFormSetPadded(threadBandwidthForm, 1);
 	uiSpinbox *threadBandwidthSpin = uiNewSpinbox(128, 40960); // 128KB/s - 40MB/s
 	uiSpinboxSetValue(threadBandwidthSpin, 2048);
-	uiFormAppend(threadBandwidthSpin, "Bandwidth Per Thread (KB/s):", uiControl(threadBandwidthSpin), 0);
-	uiBoxAppend(optionsBox, uiControl(threadBandwidthSpin), 0);
+	uiFormAppend(threadBandwidthForm, "Bandwidth Per Thread (KB/s):", uiControl(threadBandwidthSpin), 0);
+	uiBoxAppend(optionsBox, uiControl(threadBandwidthForm), 0);
 
 	uiBoxAppend(middleHorizontalBox, uiControl(uiNewVerticalSeparator()), 0);
 
@@ -182,9 +182,9 @@ uiControl *VodDownloaderDrawUi(void) {
 
 	vodOptions = malloc(sizeof(VodOptions));
 	*vodOptions = (VodOptions){
-			linkEntry, nameLabel, titleLabel, durationLabel,	createdLabel, logsEntry,		 pBar,					 status,			downloadBtn, infoBtn,
-			NULL,			 NULL,			0,					cropStartCheck, cropEndCheck, startSpinsBox, cropStartBox,	 endSpinsBox, cropEndBox,	 startHour,
-			startMin,	 startSec,	endHour,	endMin,			endSec,			OAuth,		 dwnThreadsSpin, threadBandwidthSpin, imageArea,		handler,	 0,
+			linkEntry, nameLabel, titleLabel,			durationLabel, createdLabel,	 logsEntry,						pBar,				 status,		 downloadBtn, infoBtn,	NULL,
+			NULL,			 0,					cropStartCheck, cropEndCheck,	 startSpinsBox,	 cropStartBox,				endSpinsBox, cropEndBox, startHour,		startMin, startSec,
+			endHour,	 endMin,		endSec,					OAuth,				 dwnThreadsSpin, threadBandwidthSpin, imageArea,	 handler,		 0,
 	};
 
 	uiButtonOnClicked(infoBtn, infoBtnClicked, NULL);

--- a/src/VodDownloader.h
+++ b/src/VodDownloader.h
@@ -28,6 +28,7 @@ typedef struct {
 	uiSpinbox *endSec;
 	uiEntry *OAuth;
 	uiSpinbox *dwnThreadsSpin;
+	uiSpinbox *threadBandwidthSpin;
 	uiArea *imageArea;
 	struct handler *handler;
 	pid_t downloadpid;


### PR DESCRIPTION
Since the new CLI versions have a bandwidth limiter, this GUI needs an option to configure that so downloads aren't slow. I hope this works correctly.

I also lowered the default VOD threads because we switched from `WebClient` to `HttpClient`, which changes how the "threads" behave.